### PR TITLE
Utilize Sunshine log file instead of WMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sunshine Connection Notifier
 
-Sunshine Connection Notifier is a simple program to send notifications when someone connects/disconnects to/from [Sunshine](https://github.com/LizardByte/Sunshine) host. **Works only on Windows (10/11).**
+Sunshine Connection Notifier is a simple program to send notifications when someone connects/disconnects to/from [Sunshine](https://github.com/LizardByte/Sunshine) host. **Currently works only on Windows (10/11).** There is a plan to add support for Linux/macOS.
 
 ## Installation
 
@@ -8,7 +8,6 @@ Download latest installer from releases and launch it.
 
 ## Used libraries
 
-* [WmiLight](https://github.com/MartinKuschnik/WmiLight)
 * [Microsoft.Toolkit.Uwp.Notifications](https://github.com/CommunityToolkit/WindowsCommunityToolkit)
 
 ## License

--- a/SunshineConnectionNotifier/Configuration.cs
+++ b/SunshineConnectionNotifier/Configuration.cs
@@ -2,5 +2,18 @@
 
 public class Configuration
 {
-    public int PollingInterval { get; set; } = 10000;
+    public int PollingInterval { get; set; } = 100;
+    public string LogPath { get; set; } = GetDefaultLogPath();
+
+    private static string GetDefaultLogPath()
+    {
+        if (OperatingSystem.IsWindows())
+            return $@"{Environment.GetEnvironmentVariable("ProgramFiles")}\Sunshine\config\sunshine.log";
+        if (OperatingSystem.IsLinux())
+            return @"~/.config/sunshine/sunshine.log";
+        if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst())
+            return @"~/.config/sunshine/sunshine.log";
+
+        throw new PlatformNotSupportedException();
+    }
 }

--- a/SunshineConnectionNotifier/SunshineConnectionNotifier.csproj
+++ b/SunshineConnectionNotifier/SunshineConnectionNotifier.csproj
@@ -19,13 +19,6 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="WmiLight" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="configuration.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/SunshineConnectionNotifier/configuration.example.json
+++ b/SunshineConnectionNotifier/configuration.example.json
@@ -1,0 +1,4 @@
+{
+  "pollingInterval": 500,
+  "logPath": "C:\\Program Files\\Sunshine\\config\\sunshine.log"
+}

--- a/SunshineConnectionNotifier/configuration.json
+++ b/SunshineConnectionNotifier/configuration.json
@@ -1,3 +1,0 @@
-{
-  "pollingInterval": 10000 
-}


### PR DESCRIPTION
Sunshine writes about connections to it's log. So we can check information faster and not use WMI.

WMI is not used anymore, so dependency on WmiLight is no longer needed.

FileSystemWatcher is not used, because it is not fired on log changes, because the file is not closed by Sunshine. So checking for new lines in the log file is comparable to watcher in terms of implementation, difference in performance is expected to be minimal. Obviously polling interval is lowered down to 100 ms.

Configuration is now served as overrides to exclude writing log path into configuration file when loading from defaults.

Also program now gracefully exits when it is requested to exit.